### PR TITLE
Several spell casts for party and enemies/unique enemies

### DIFF
--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
@@ -265,6 +265,7 @@ local function onSessionLoaded()
     print("CombatReRandomizer ver. 0.7.1 initialization")
     ApiWrapper.initializeModApi(modApi)
     BoostUtils.initialize(modApi)
+    SpellUtils.initialize(modApi)
     UniqueEnemiesModule.initialize(modApi)
 
     local modvars = getModvars()

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
@@ -766,10 +766,10 @@ local function giveSpells(charId, multiplierOption)
         for i = 1, numSpellsToAdd do
             local randomSpell = getValidSpell(disallowSummonSpells)
             if randomSpell then
-                SpellUtils.addSpellCastToCharacter(charId, randomSpell)
+                local casts = SpellUtils.addSpellCastToCharacter(charId, randomSpell)
                 if RandomizerConfig.ConsoleDebug then
                     print("Giving spell to: " .. parseStringFromGuid(charId) ..
-                        " spell: " .. randomSpell .. " (casts left: " .. characterSpells[charId][randomSpell] .. ")")
+                        " spell: " .. randomSpell .. " (casts left: " .. casts .. ")")
                 end
             else
                 if RandomizerConfig.ConsoleExtraDebug then
@@ -856,21 +856,10 @@ end
 
 -- Helper function: Add or increment spell casts
 local function addOrIncrementSpell(charId, spell)
-    if not spellsAddedToParty[charId] then
-        spellsAddedToParty[charId] = {}
-    end
-    if spellsAddedToParty[charId][spell] then
-        -- Increment casts left if the spell is already added
-        spellsAddedToParty[charId][spell] = spellsAddedToParty[charId][spell] + 1
-    else
-        -- Add new spell with 1 cast
-        spellsAddedToParty[charId][spell] = 1
-        modApi.AddSpell(charId, spell)
-    end
-
+    local casts = SpellUtils.addSpellCastToPartyMember(charId, spell)
     if RandomizerConfig.ConsoleDebug then
         print("Adding spell to: " .. parseStringFromGuid(charId) ..
-            " spell: " .. spell .. " (casts left: " .. spellsAddedToParty[charId][spell] .. ")")
+            " spell: " .. spell .. " (casts left: " .. casts .. ")")
     end
 end
 
@@ -1243,7 +1232,7 @@ Ext.Osiris.RegisterListener("CastedSpell", 5, "after", function(casterId, spell,
     elseif isRandomizedChar(casterId) then
         handleNpcCastedSpellEvent(casterId, spell)
         -- Check for "_AI" suffix and rerun with stripped spell if necessary (ex. Target_MagicMissile_AI)
-         if spell:sub(-3) == "_AI" then
+        if spell:sub(-3) == "_AI" then
             local originalSpell = spell:sub(1, -4) -- Remove "_AI" from the end
             if RandomizerConfig.ConsoleDebug then
                 print("Detected _AI suffix. Rerunning with spell: ", originalSpell)

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
@@ -1,4 +1,3 @@
-local Ext = Ext
 local BaseRandomizablesList = Ext.Require("CombatReRandomizer/StaticData/BaseRandomizableLists.lua")
 local StaticLists = Ext.Require("CombatReRandomizer/StaticData/StaticLists.lua")
 

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
@@ -1,3 +1,4 @@
+local Ext = Ext
 local BaseRandomizablesList = Ext.Require("CombatReRandomizer/StaticData/BaseRandomizableLists.lua")
 local StaticLists = Ext.Require("CombatReRandomizer/StaticData/StaticLists.lua")
 
@@ -95,7 +96,9 @@ end
 
 local function addItemsFromJson(sourceTable, targetList, label)
     for _, item in ipairs(sourceTable) do
-        print("Combat ReRandomizer - adding modded " .. label .. ": " .. item)
+        if RandomizerConfig.ConsoleExtraDebug then
+            print("Combat ReRandomizer - adding modded " .. label .. ": " .. item)
+        end
         table.insert(targetList, item)
     end
 end
@@ -210,6 +213,11 @@ end
 
 -- Process and deduplicate spells, replacing them with container spells or root spells if applicable
 local function processRandomizableSpells()
+    if RandomizerConfig.ConsoleExtraDebug then
+        print("-----------------------------------------------")
+        print("Processing randomizable spells")
+    end
+
     -- Replace spells with container or root spells
     for i, spell in ipairs(RandomizablesLists.Spells) do
         local containerSpell = SpellUtils.getSpellContainer(spell)
@@ -243,6 +251,7 @@ local function processRandomizableSpells()
 
     if RandomizerConfig.ConsoleExtraDebug then
         print(#deduplicatedList .. " unique spells are ready to be randomized")
+        print("-----------------------------------------------")
     end
     -- Replace the original list with the deduplicated list
     RandomizablesLists.Spells = deduplicatedList
@@ -914,9 +923,6 @@ end
 
 local function fullyEquipItemForChar(itemId, charId)
     modApi.Equip(charId, itemId)
-    if (RandomizerConfig.ConsoleExtraDebug) then
-        print("Character: " .. parseStringFromGuid(charId) .. " equiped: " .. parseStringFromGuid(itemId))
-    end
 end
 
 Ext.Events.SessionLoaded:Subscribe(onSessionLoaded)
@@ -1188,7 +1194,7 @@ local function removeCharacterSpellFromChar(spell, charId)
             -- Log remaining casts if the spell is not fully removed
             if RandomizerConfig.ConsoleDebug then
                 print("Decrementing spell: " .. spell .. ", for npc: " .. parseStringFromGuid(charId) ..
-                      ". Casts left: " .. characterSpells[charId][spell])
+                    ". Casts left: " .. characterSpells[charId][spell])
             end
         end
     end

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
@@ -1242,7 +1242,7 @@ Ext.Osiris.RegisterListener("CastedSpell", 5, "after", function(casterId, spell,
         handlePartyMemberCastedSpellEvent(casterId, spell)
     elseif isRandomizedChar(casterId) then
         handleNpcCastedSpellEvent(casterId, spell)
-         -- Check for "_AI" suffix and rerun with stripped spell if necessary
+        -- Check for "_AI" suffix and rerun with stripped spell if necessary (ex. Target_MagicMissile_AI)
          if spell:sub(-3) == "_AI" then
             local originalSpell = spell:sub(1, -4) -- Remove "_AI" from the end
             if RandomizerConfig.ConsoleDebug then

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/StaticData/ReRandomizerBaseUniques.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/StaticData/ReRandomizerBaseUniques.lua
@@ -41,6 +41,10 @@ local baseUniques = [[{
         "statuses": [
           { "type": "UncannyDodge", "duration": 6 }
         ],
+        "spells": [
+          { "spell": "Projectile_MagicMissile", "casts": 3 },
+          { "spell": "Shout_Blur" }
+        ],
         "whitelist": ["Celestial Shield"],
         "blacklist": [],
         "weight": 60

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/JsonValidator.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/JsonValidator.lua
@@ -14,6 +14,7 @@ local function validateAndConvert(jsonData)
         local converted = {
             boosts = {},
             statuses = {},
+            spells = {},
             blacklist = {},
             whitelist = {},
             weight = weightValue and math.max(weightValue, 1) or 100
@@ -118,6 +119,24 @@ local function validateAndConvert(jsonData)
                 table.insert(converted.statuses, {
                     type = status.type,
                     duration = default(status.duration, -1)
+                })
+            end
+        end
+
+        -- Validate and convert spells
+        if uniqueData.spells then
+            for _, spellData in ipairs(uniqueData.spells) do
+                if not spellData.spell then
+                    logErrorAndSkip("spellData.type")
+                    goto continue
+                end
+                if spellData.casts ~= nil and (type(spellData.casts) ~= "number" or spellData.casts < 0) then
+                    logErrorAndSkip("spells.casts", "must be a positive number or nothing(infinite)")
+                    goto continue
+                end
+                table.insert(converted.statuses, {
+                    spell = spellData.spell,
+                    casts = default(spellData.casts, nil)
                 })
             end
         end

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/JsonValidator.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/JsonValidator.lua
@@ -127,14 +127,14 @@ local function validateAndConvert(jsonData)
         if uniqueData.spells then
             for _, spellData in ipairs(uniqueData.spells) do
                 if not spellData.spell then
-                    logErrorAndSkip("spellData.type")
+                    logErrorAndSkip("spellData.spell")
                     goto continue
                 end
                 if spellData.casts ~= nil and (type(spellData.casts) ~= "number" or spellData.casts < 0) then
                     logErrorAndSkip("spells.casts", "must be a positive number or nothing(infinite)")
                     goto continue
                 end
-                table.insert(converted.statuses, {
+                table.insert(converted.spells, {
                     spell = spellData.spell,
                     casts = default(spellData.casts, nil)
                 })

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/UniqueEnemies.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/UniqueEnemies.lua
@@ -10,6 +10,7 @@ local RandomizerConfig = RandomizerConfigData.RandomizerConfig
 -- Utils
 local BoostUtils = Ext.Require("CombatReRandomizer/Utils/BoostUtils.lua")
 local MathUtils = Ext.Require("CombatReRandomizer/Utils/MathUtils.lua")
+local SpellUtils = Ext.Require("CombatReRandomizer/Utils/SpellUtils.lua")
 
 -- Json validator/converter
 local JsonConverter = Ext.Require("CombatReRandomizer/UniqueEnemies/JsonValidator.lua")
@@ -17,6 +18,9 @@ local JsonConverter = Ext.Require("CombatReRandomizer/UniqueEnemies/JsonValidato
 local UniqueEnemiesModule = {}
 
 local modApi = {}
+
+-- Persistence: Local lists
+local characterSpells = Persistence.characterSpells
 
 -- Set up BoostUtils with the wrapped modApi
 function UniqueEnemiesModule.initialize(wrappedModApi)
@@ -140,7 +144,15 @@ end
         ]
 ]]
 local function giveSpells(charId, spells)
-    
+    for _, spellData in ipairs(spells) do
+        if spellData.spell then
+            if spellData.casts then
+                SpellUtils.addSpellCastsToCharacter(charId, spellData.spell, spellData.casts)
+            else
+                SpellUtils.addSpellToCharacter(charId, spellData.spell)
+            end
+        end
+    end
 end
 
 -- Function to apply a single unique type (buffs, boosts etc.) to a character

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/UniqueEnemies.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/UniqueEnemies.lua
@@ -1,3 +1,4 @@
+local Ext = Ext
 -- Shared data
 local Persistence = Ext.Require("CombatReRandomizer/SharedData/Persistence.lua")
 local RandomizerConfigData = Ext.Require("CombatReRandomizer/SharedData/RandomizerConfig.lua")

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/UniqueEnemies.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/UniqueEnemies.lua
@@ -27,6 +27,7 @@ local characterSpells = Persistence.characterSpells
 function UniqueEnemiesModule.initialize(wrappedModApi)
     modApi = wrappedModApi
     BoostUtils.initialize(wrappedModApi)
+    SpellUtils.initialize(wrappedModApi)
 end
 
 -- Define unique types with dictionary-based whitelist and blacklist

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/UniqueEnemies.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/UniqueEnemies.lua
@@ -1,4 +1,3 @@
-local Ext = Ext
 -- Shared data
 local Persistence = Ext.Require("CombatReRandomizer/SharedData/Persistence.lua")
 local RandomizerConfigData = Ext.Require("CombatReRandomizer/SharedData/RandomizerConfig.lua")

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/UniqueEnemies.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/UniqueEnemies/UniqueEnemies.lua
@@ -245,8 +245,43 @@ function UniqueEnemiesModule.applyUniqueModifiers(charId)
     return currentUniques
 end
 
+local function validateSpellContainers(uniqueTypes)
+    for uniqueType, uniqueData in pairs(uniqueTypes) do
+        if uniqueData.spells then
+            local updatedSpells = {}
+            for _, spellData in ipairs(uniqueData.spells) do
+                local containerSpell = SpellUtils.getSpellContainer(spellData.spell)
+                if containerSpell and containerSpell ~= "" then
+                    table.insert(updatedSpells, containerSpell)
+                    if RandomizerConfig.ConsoleDebug then
+                        print("Spell: ".. spellData.spell .." added to unique type: " .. uniqueType
+                         .. "was replaced with container spell: " .. containerSpell)
+                         print("If this is unexpected, please adjust CombatReRandomizerUniques.json")
+                    end
+                else
+                    local rootSpell = SpellUtils.getRootSpell(spellData.spell)
+                    if rootSpell then
+                        table.insert(updatedSpells, rootSpell)
+                        if RandomizerConfig.ConsoleExtraDebug then
+                            print("Spell: ".. spellData.spell .." added to unique type: " .. uniqueType
+                         .. "was replaced with root spell: " .. rootSpell)
+                         print("If this is unexpected, please adjust CombatReRandomizerUniques.json")
+                        end
+                    else
+                        table.insert(updatedSpells, spellData.spell)
+                    end
+                end
+            end
+            uniqueTypes[uniqueType].spells = updatedSpells
+        end
+    end
+    return uniqueTypes
+end
+
+
 function UniqueEnemiesModule.parseUniques(uniquesJson)
     local uniqueTypes = JsonConverter(uniquesJson)
+    uniqueTypes = validateSpellContainers(uniqueTypes)
 
     -- Assign to UniqueTypes if it is successfully converted
     if uniqueTypes then

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/Utils/SpellUtils.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/Utils/SpellUtils.lua
@@ -34,7 +34,7 @@ end
 -- Function to return root spell if it exists
 function SpellUtils.getRootSpell(spell)
     local spellData = Ext.Stats.Get(spell, nil, false)
-    if spellData and (not spellData.RootSpellID or spellData.RootSpellID == "") then
+    if spellData and (spellData.RootSpellID and not spellData.RootSpellID == "") then
         return spellData.RootSpellID
     end
     return nil -- Returns false if it's not a root spell or spell doesn't exist

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/Utils/SpellUtils.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/Utils/SpellUtils.lua
@@ -4,13 +4,8 @@ local SpellUtils = {}
 
 local modApi = {}
 
--- Persistence: Local lists
-local characterSpells = Persistence.characterSpells
-local spellsAddedToParty = Persistence.spellsAddedToParty
-
--- Set up BoostUtils with the wrapped modApi
 function SpellUtils.initialize(wrappedModApi)
-    modApi = wrappedModApi  -- Store the reference to modApi in a local variable
+    modApi = wrappedModApi  -- Store the mod API reference
 end
 
 -- Spells
@@ -96,108 +91,108 @@ end
 -- Function to add a single spell cast to npc with persistence tracking
 function SpellUtils.addSpellCastToCharacter(charId, spell)
     -- Initialize characterSpells[charId] if it doesn't exist
-    if not characterSpells[charId] then
-        characterSpells[charId] = {}
+    if not Persistence.characterSpells[charId] then
+        Persistence.characterSpells[charId] = {}
     end
-    if characterSpells[charId][spell] then
+    if Persistence.characterSpells[charId][spell] then
         -- Increment casts if the spell is already present
-        characterSpells[charId][spell] = characterSpells[charId][spell] + 1
+        Persistence.characterSpells[charId][spell] = Persistence.characterSpells[charId][spell] + 1
     else
         -- Add new spell with 1 cast
-        characterSpells[charId][spell] = 1
+        Persistence.characterSpells[charId][spell] = 1
         modApi.AddSpell(charId, spell)
     end
-    return characterSpells[charId][spell]
+    return Persistence.characterSpells[charId][spell]
 end
 
 -- Function to add a several spell casts to npc with persistence tracking
 function SpellUtils.addSpellCastsToCharacter(charId, spell, castCount)
     -- Initialize characterSpells[charId] if it doesn't exist
-    if not characterSpells[charId] then
-        characterSpells[charId] = {}
+    if not Persistence.characterSpells[charId] then
+        Persistence.characterSpells[charId] = {}
     end
-    if characterSpells[charId][spell] then
+    if Persistence.characterSpells[charId][spell] then
         -- Increment casts if the spell is already present
-        characterSpells[charId][spell] = characterSpells[charId][spell] + castCount
+        Persistence.characterSpells[charId][spell] = Persistence.characterSpells[charId][spell] + castCount
     else
         -- Add new spell with given cast count
-        characterSpells[charId][spell] = castCount
+        Persistence.characterSpells[charId][spell] = castCount
         modApi.AddSpell(charId, spell)
     end
-    return characterSpells[charId][spell]
+    return Persistence.characterSpells[charId][spell]
 end
 
 -- Function to add a spell (near infinite casts) to npc with persistence tracking
 function SpellUtils.addSpellToCharacter(charId, spell)
     -- Initialize characterSpells[charId] if it doesn't exist
-    if not characterSpells[charId] then
-        characterSpells[charId] = {}
+    if not Persistence.characterSpells[charId] then
+        Persistence.characterSpells[charId] = {}
     end
-    if characterSpells[charId][spell] then
+    if Persistence.characterSpells[charId][spell] then
         -- Rewrite to near infinite casts if it already has some
-        characterSpells[charId][spell] = 9001
+        Persistence.characterSpells[charId][spell] = 9001
     else
         -- Add new spell with near infinite casts
-        characterSpells[charId][spell] = 9001
+        Persistence.characterSpells[charId][spell] = 9001
         modApi.AddSpell(charId, spell)
     end
 end
 
 -- Function to add a single spell cast to a party member with persistence tracking
 function SpellUtils.addSpellCastToPartyMember(charId, spell)
-    if not spellsAddedToParty[charId] then
-        spellsAddedToParty[charId] = {}
+    if not Persistence.spellsAddedToParty[charId] then
+        Persistence.spellsAddedToParty[charId] = {}
     end
-    if spellsAddedToParty[charId][spell] then
+    if Persistence.spellsAddedToParty[charId][spell] then
         -- Increment casts left if the spell is already added
-        spellsAddedToParty[charId][spell] = spellsAddedToParty[charId][spell] + 1
+        Persistence.spellsAddedToParty[charId][spell] = Persistence.spellsAddedToParty[charId][spell] + 1
     else
         -- Add new spell with 1 cast
-        spellsAddedToParty[charId][spell] = 1
+        Persistence.spellsAddedToParty[charId][spell] = 1
         modApi.AddSpell(charId, spell)
     end
-    return characterSpells[charId][spell]
+    return Persistence.spellsAddedToParty[charId][spell]
 end
 
 -- Function to add a several spell casts to a party member with persistence tracking
 function SpellUtils.addSpellCastsToPartyMember(charId, spell, castCount)
-    if not spellsAddedToParty[charId] then
-        spellsAddedToParty[charId] = {}
+    if not Persistence.spellsAddedToParty[charId] then
+        Persistence.spellsAddedToParty[charId] = {}
     end
-    if spellsAddedToParty[charId][spell] then
+    if Persistence.spellsAddedToParty[charId][spell] then
         -- Increment casts left if the spell is already added
-        spellsAddedToParty[charId][spell] = spellsAddedToParty[charId][spell] + castCount
+        Persistence.spellsAddedToParty[charId][spell] = Persistence.spellsAddedToParty[charId][spell] + castCount
     else
         -- Add new spell with given cast count
-        spellsAddedToParty[charId][spell] = castCount
+        Persistence.spellsAddedToParty[charId][spell] = castCount
         modApi.AddSpell(charId, spell)
     end
-    return characterSpells[charId][spell]
+    return Persistence.spellsAddedToParty[charId][spell]
 end
 
 function SpellUtils.removeSpellCastFromCharacter(charId, spell)
-    if characterSpells[charId] and characterSpells[charId][spell] then
+    if Persistence.characterSpells[charId] and Persistence.characterSpells[charId][spell] then
         -- Decrement the number of casts left
-        characterSpells[charId][spell] = characterSpells[charId][spell] - 1
-        if characterSpells[charId][spell] <= 0 then
+        Persistence.characterSpells[charId][spell] = Persistence.characterSpells[charId][spell] - 1
+        if Persistence.characterSpells[charId][spell] <= 0 then
             modApi.RemoveSpell(charId, spell, 1)
-            characterSpells[charId][spell] = nil
+            Persistence.characterSpells[charId][spell] = nil
             return nil
         end
-        return characterSpells[charId][spell]
+        return Persistence.characterSpells[charId][spell]
     end
     return nil
 end
 
 function SpellUtils.removeSpellCastFromPartyMember(charId, spell)
-    if spellsAddedToParty[charId] and spellsAddedToParty[charId][spell] then
-        spellsAddedToParty[charId][spell] = spellsAddedToParty[charId][spell] - 1
-        if spellsAddedToParty[charId][spell] <= 0 then
+    if Persistence.spellsAddedToParty[charId] and Persistence.spellsAddedToParty[charId][spell] then
+        Persistence.spellsAddedToParty[charId][spell] = Persistence.spellsAddedToParty[charId][spell] - 1
+        if Persistence.spellsAddedToParty[charId][spell] <= 0 then
             modApi.RemoveSpell(charId, spell)
-            spellsAddedToParty[charId][spell] = nil
+            Persistence.spellsAddedToParty[charId][spell] = nil
             return nil
         end
-        return spellsAddedToParty[charId][spell]
+        return Persistence.spellsAddedToParty[charId][spell]
     end
     return nil
 end

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/Utils/SpellUtils.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/Utils/SpellUtils.lua
@@ -1,0 +1,174 @@
+local Persistence = Ext.Require("CombatReRandomizer/SharedData/Persistence.lua")
+
+local SpellUtils = {}
+
+local modApi = {}
+
+-- Persistence: Local lists
+local characterSpells = Persistence.characterSpells
+local spellsAddedToParty = Persistence.spellsAddedToParty
+
+-- Set up BoostUtils with the wrapped modApi
+function SpellUtils.initialize(wrappedModApi)
+    modApi = wrappedModApi  -- Store the reference to modApi in a local variable
+end
+
+-- Spells
+function SpellUtils.getSpellContainer(spell)
+    local spellData = Ext.Stats.Get(spell, nil, false)
+    if spellData and spellData.SpellContainerID ~= "" then
+        return spellData.SpellContainerID
+    end
+    return "" -- Return an empty string if there's no container or spell doesn't exist
+end
+
+-- Function to check if a spell is a root spell
+function SpellUtils.isRootSpell(spell)
+    local spellData = Ext.Stats.Get(spell, nil, false)
+    if spellData and (not spellData.RootSpellID or spellData.RootSpellID == "") then
+        return true
+    end
+    return false -- Returns false if it's not a root spell or spell doesn't exist
+end
+
+-- Function to return root spell if it exists
+function SpellUtils.getRootSpell(spell)
+    local spellData = Ext.Stats.Get(spell, nil, false)
+    if spellData and (not spellData.RootSpellID or spellData.RootSpellID == "") then
+        return spellData.RootSpellID
+    end
+    return nil -- Returns false if it's not a root spell or spell doesn't exist
+end
+
+-- Helper function to check if a functor has summoning properties
+local function isSummoningProperty(functor)
+    return functor.TypeId == "Summon" or functor.TypeId == "Spawn"
+end
+
+-- Helper function to check if any of the spell's properties meet summoning conditions
+function SpellUtils.hasSummoningProperties(spellData)
+    if spellData and spellData.SpellProperties then
+        for _, property in pairs(spellData.SpellProperties) do
+            if property.Functors then
+                for _, functor in pairs(property.Functors) do
+                    if isSummoningProperty(functor) then
+                        return true
+                    end
+                end
+            end
+        end
+    end
+    return false
+end
+
+local function splitContainerSpells(input, separator)
+    local result = {}
+    for match in (input .. separator):gmatch("(.-)" .. separator) do
+        table.insert(result, match)
+    end
+    return result
+end
+
+-- Main function to check if a spell or any of its container spells are summoning spells
+function SpellUtils.isSummoningSpell(spell)
+    local spellData = Ext.Stats.Get(spell)
+
+    -- Step 1: Check the main spell for summoning properties
+    if SpellUtils.hasSummoningProperties(spellData) then
+        return true
+    end
+
+    -- Step 2: If the spell is a container, check each contained spell
+    if spellData and spellData.ContainerSpells then
+        -- Split the "ContainerSpells" string into individual spells
+        local containerSpells = splitContainerSpells(spellData.ContainerSpells, ";")
+        for _, containedSpell in ipairs(containerSpells) do
+            local containedSpellData = Ext.Stats.Get(containedSpell)
+            if SpellUtils.hasSummoningProperties(containedSpellData) then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+-- Function to add a single spell cast to npc with persistence tracking
+function SpellUtils.addSpellCastToCharacter(charId, spell)
+    -- Initialize characterSpells[charId] if it doesn't exist
+    if not characterSpells[charId] then
+        characterSpells[charId] = {}
+    end
+    if characterSpells[charId][spell] then
+        -- Increment casts if the spell is already present
+        characterSpells[charId][spell] = characterSpells[charId][spell] + 1
+    else
+        -- Add new spell with 1 cast
+        characterSpells[charId][spell] = 1
+        modApi.AddSpell(charId, spell)
+    end
+end
+
+-- Function to add a several spell casts to npc with persistence tracking
+function SpellUtils.addSpellCastsToCharacter(charId, spell, castCount)
+    -- Initialize characterSpells[charId] if it doesn't exist
+    if not characterSpells[charId] then
+        characterSpells[charId] = {}
+    end
+    if characterSpells[charId][spell] then
+        -- Increment casts if the spell is already present
+        characterSpells[charId][spell] = characterSpells[charId][spell] + castCount
+    else
+        -- Add new spell with given cast count
+        characterSpells[charId][spell] = castCount
+        modApi.AddSpell(charId, spell)
+    end
+end
+
+-- Function to add a spell (near infinite casts) to npc with persistence tracking
+function SpellUtils.addSpellToCharacter(charId, spell)
+    -- Initialize characterSpells[charId] if it doesn't exist
+    if not characterSpells[charId] then
+        characterSpells[charId] = {}
+    end
+    if characterSpells[charId][spell] then
+        -- Rewrite to near infinite casts if it already has some
+        characterSpells[charId][spell] = 9001
+    else
+        -- Add new spell with near infinite casts
+        characterSpells[charId][spell] = 9001
+        modApi.AddSpell(charId, spell)
+    end
+end
+
+-- Function to add a single spell cast to a party member with persistence tracking
+function SpellUtils.addSpellCastToPartyMember(charId, spell)
+    if not spellsAddedToParty[charId] then
+        spellsAddedToParty[charId] = {}
+    end
+    if spellsAddedToParty[charId][spell] then
+        -- Increment casts left if the spell is already added
+        spellsAddedToParty[charId][spell] = spellsAddedToParty[charId][spell] + 1
+    else
+        -- Add new spell with 1 cast
+        spellsAddedToParty[charId][spell] = 1
+        modApi.AddSpell(charId, spell)
+    end
+end
+
+-- Function to add a several spell casts to a party member with persistence tracking
+function SpellUtils.addSpellCastsToPartyMember(charId, spell, castCount)
+    if not spellsAddedToParty[charId] then
+        spellsAddedToParty[charId] = {}
+    end
+    if spellsAddedToParty[charId][spell] then
+        -- Increment casts left if the spell is already added
+        spellsAddedToParty[charId][spell] = spellsAddedToParty[charId][spell] + castCount
+    else
+        -- Add new spell with given cast count
+        spellsAddedToParty[charId][spell] = castCount
+        modApi.AddSpell(charId, spell)
+    end
+end
+
+return SpellUtils

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/Utils/SpellUtils.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/Utils/SpellUtils.lua
@@ -107,6 +107,7 @@ function SpellUtils.addSpellCastToCharacter(charId, spell)
         characterSpells[charId][spell] = 1
         modApi.AddSpell(charId, spell)
     end
+    return characterSpells[charId][spell]
 end
 
 -- Function to add a several spell casts to npc with persistence tracking
@@ -123,6 +124,7 @@ function SpellUtils.addSpellCastsToCharacter(charId, spell, castCount)
         characterSpells[charId][spell] = castCount
         modApi.AddSpell(charId, spell)
     end
+    return characterSpells[charId][spell]
 end
 
 -- Function to add a spell (near infinite casts) to npc with persistence tracking
@@ -154,6 +156,7 @@ function SpellUtils.addSpellCastToPartyMember(charId, spell)
         spellsAddedToParty[charId][spell] = 1
         modApi.AddSpell(charId, spell)
     end
+    return characterSpells[charId][spell]
 end
 
 -- Function to add a several spell casts to a party member with persistence tracking
@@ -169,6 +172,34 @@ function SpellUtils.addSpellCastsToPartyMember(charId, spell, castCount)
         spellsAddedToParty[charId][spell] = castCount
         modApi.AddSpell(charId, spell)
     end
+    return characterSpells[charId][spell]
+end
+
+function SpellUtils.removeSpellCastFromCharacter(charId, spell)
+    if characterSpells[charId] and characterSpells[charId][spell] then
+        -- Decrement the number of casts left
+        characterSpells[charId][spell] = characterSpells[charId][spell] - 1
+        if characterSpells[charId][spell] <= 0 then
+            modApi.RemoveSpell(charId, spell, 1)
+            characterSpells[charId][spell] = nil
+            return nil
+        end
+        return characterSpells[charId][spell]
+    end
+    return nil
+end
+
+function SpellUtils.removeSpellCastFromPartyMember(charId, spell)
+    if spellsAddedToParty[charId] and spellsAddedToParty[charId][spell] then
+        spellsAddedToParty[charId][spell] = spellsAddedToParty[charId][spell] - 1
+        if spellsAddedToParty[charId][spell] <= 0 then
+            modApi.RemoveSpell(charId, spell)
+            spellsAddedToParty[charId][spell] = nil
+            return nil
+        end
+        return spellsAddedToParty[charId][spell]
+    end
+    return nil
 end
 
 return SpellUtils


### PR DESCRIPTION
Addition of SpellUtills, that handles cross file needs of adding spells / spell casts. Spell casts are just in memory numbers that help determine if the spell should be removed after casting or not.

Also includes refactor to Persistence. It was done because there was a mistake in it working cross files, and the fact that just referencing the table that modvars are at is not enough to update it, you need explicit declaration (Or at least that is how I understood), now should work correct. Also simplified reassignment/update of modvars as there was a lot of code duplication. Now it is handled by the helper functions:
`persistAllData()`
`persistItemData()`
`persistPartyData()`

That will reassign modvars depending on what was changed.