### PR TITLE
Add maximum amount of spells to potentially reduce lag for powerful enemies

### DIFF
--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
@@ -797,11 +797,15 @@ local function getValidSpell(disallowSummonSpells)
     return spell
 end
 
+local function calculateSpellAmount(charId, multiplierOption)
+    local levelFactor = math.max(1.0, modApi.GetLevel(charId) / 2.0)
+    local amount = getAdditionalStrengthMultiplier(multiplierOption) * levelFactor
+    return MathUtils.mathRound(math.min(amount, 8))
+end
+
 local function giveSpells(charId, multiplierOption)
     if MathUtils.isGreaterOrEqualThanRandom(RandomizerConfig.NpcSpells) then
-        local numSpellsToAdd = MathUtils.mathRound(
-            getAdditionalStrengthMultiplier(multiplierOption) * math.max(1.0, modApi.GetLevel(charId) / 2.0)
-        )
+        local numSpellsToAdd = calculateSpellAmount(charId, multiplierOption)
 
         -- Determine whether summon spells should be disallowed
         local disallowSummonSpells = modApi.IsSummon(charId)


### PR DESCRIPTION
Capping max amount of spells NPCs get to 8.

Not sure if this is an issue, but seems that strong enemies with lots of spells can take a while to make decisions. Should reduce decision tree by a big amount for powerful enemies like super elites and ultra elites so they can take their turns more efficiently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined NPC spell allocation calculations for improved balance. Spells are now distributed based on character level with a maximum cap of 8 spells per NPC.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->