### PR TITLE
Npc Spell amount config

### DIFF
--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
@@ -800,7 +800,7 @@ end
 local function calculateSpellAmount(charId, multiplierOption)
     local levelFactor = math.max(1.0, modApi.GetLevel(charId) / 2.0)
     local amount = getAdditionalStrengthMultiplier(multiplierOption) * levelFactor
-    return MathUtils.mathRound(math.min(amount, 8))
+    return MathUtils.mathRound(math.min(amount, RandomizerConfig.MaxNpcSpells))
 end
 
 local function giveSpells(charId, multiplierOption)

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/SharedData/RandomizerConfig.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/SharedData/RandomizerConfig.lua
@@ -4,6 +4,7 @@ Data.RandomizerConfig = {
     Randomness = 25,
     NpcEquipment = 50,
     NpcSpells = 50,
+    MaxNpcSpells = 5,
     EnemiesOnly = false,
     ResourceBoosts = 50,
     Statuses = 50,

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/StaticData/ReRandomizerBaseConfig.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/StaticData/ReRandomizerBaseConfig.lua
@@ -2,6 +2,7 @@ local baseConfig = [[{
     "Randomness": 90,
     "NpcEquipment": 75,
     "NpcSpells": 50,
+    "MaxNpcSpells": 5,
     "EnemiesOnly": false,
     "ResourceBoosts": 50,
     "Statuses": 50,

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/StaticData/ReRandomizerBaseWeights.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/StaticData/ReRandomizerBaseWeights.lua
@@ -10,7 +10,6 @@ local baseConfig = [[{
     "SuperEliteItemDropChance": 2.0,
     "UniquePowerScale": 1.0,
     "ConsumablesMultiplier": 2.0
-    ""
 }]]
 
 return baseConfig


### PR DESCRIPTION
Added a config setting to set the max amount of spells npc' s can get.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NPC spells in combat randomization are now configurable with a maximum limit (default: 5 spells per NPC), enabling fine-tuned control over spell distribution in randomized encounters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->