### PR TITLE
Feature for items to be added to inventory

### DIFF
--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/CombatReRandomizer.lua
@@ -468,6 +468,19 @@ local function giveRandomEquipment(charId)
             addItemToCharacter(rndItemTemplate, charId)
         end
     end
+
+    for _, equipment in ipairs(equipmentList) do
+        local dropChance = RandomizerConfig.NpcLootGear *
+            ((uniqueProperties[charId] and uniqueProperties[charId].ItemDropMultiplier) or 1.0)
+        if MathUtils.isGreaterOrEqualThanRandom(dropChance) then
+            local rndItemTemplate = getRandomItemFromList(equipment.list)
+            modApi.TemplateAddTo(rndItemTemplate, charId, 1)
+
+            if RandomizerConfig.ConsoleDebug then
+                print("Gained loot: " .. rndItemTemplate .. " with a drop chance of " .. dropChance)
+            end
+        end
+    end
 end
 
 local function giveConsumables(charId, multiplierOption)

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/SharedData/RandomizerConfig.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/SharedData/RandomizerConfig.lua
@@ -3,6 +3,7 @@ local Data = {}
 Data.RandomizerConfig = {
     Randomness = 25,
     NpcEquipment = 50,
+    NpcLootGear = 0.5,
     NpcSpells = 50,
     EnemiesOnly = false,
     ResourceBoosts = 50,

--- a/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/StaticData/ReRandomizerBaseConfig.lua
+++ b/Mods/Combat_Re_Randomizer/ScriptExtender/Lua/CombatReRandomizer/StaticData/ReRandomizerBaseConfig.lua
@@ -1,6 +1,7 @@
 local baseConfig = [[{
     "Randomness": 90,
     "NpcEquipment": 75,
+    "NpcLootGear": 0.5,
     "NpcSpells": 50,
     "EnemiesOnly": false,
     "ResourceBoosts": 50,


### PR DESCRIPTION
Added a Feature for items to be added to inventory and not equipped. Also the needed config settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced independent gear loot drops per equipment category with probability-based mechanics
  * Added configurable NPC gear loot drop rate (default 50%) to adjust equipment rewards
  * Optional debug logging now displays acquired loot when enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->